### PR TITLE
Bug fix read pseudos

### DIFF
--- a/Modules/pseudo_types.f90
+++ b/Modules/pseudo_types.f90
@@ -51,7 +51,7 @@
           LOGICAL :: tvanp              ! .true. if Ultrasoft
           LOGICAL :: tcoulombp          ! .true. if Coulomb 1/r potential
           LOGICAL :: nlcc               ! Non linear core corrections
-          CHARACTER(LEN=20) :: dft      ! Exch-Corr type
+          CHARACTER(LEN=25) :: dft      ! Exch-Corr type
           REAL(DP) :: zp                ! z valence
           REAL(DP) :: etotps            ! total energy
           REAL(DP) :: ecutwfc           ! suggested cut-off for wfc


### PR DESCRIPTION
This MR fixes a small bug in the subroutine that reads the pseudos.
The lenght of the dft name in the pseudo metadata is increased to allow for longer name. This fixes iotk error appearing when reading, e.g. dojo pseudos shipped with the `koopman` package (but possibly relevant also for other pseudo libs).