### PR TITLE
Tweak phasefactor implementation so that it does not trigger an ifx bug

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -21,7 +21,7 @@ jobs:
          - name: Install dependencies
            run: |
               sudo apt-get update
-              sudo apt-get install gfortran libopenmpi-dev libblas-dev liblapack-dev fftw3-dev
+              sudo apt-get install gfortran libopenmpi-dev libblas-dev liblapack-dev libfftw3-dev
          - name: Configure
            run: |
               ./configure MPIF90=mpif90

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -33,7 +33,7 @@ jobs:
               make check
          - name: Upload
            if: success() || failure()
-           uses: actions/upload-artifact@v3
+           uses: actions/upload-artifact@v4
            with:
              name: test-data
              path: |

--- a/CPV/phasefactor.f90
+++ b/CPV/phasefactor.f90
@@ -30,7 +30,6 @@
  
           USE kinds,           ONLY: DP
           USE constants,       ONLY: tpi
-          use ieee_arithmetic, only: ieee_is_nan
 
           IMPLICIT NONE
 
@@ -105,22 +104,18 @@
                 ei3(k, isa) = ei3(0, isa) * ctep3 ** k
                 ei3(-k, isa) = ei3(0, isa) * ctem3 ** k
               END DO
+
           END DO
-          write(*, *) 'ei1', ei1
-          write(*, *) 'ei2', ei2
-          write(*, *) 'ei3', ei3
 
           ngw = SIZE( eigr, 1 )
           IF( ngw > SIZE( mill, 2 ) ) THEN
             CALL errore(' phfacs ',' eigr inconsisten size ',ngw)
           END IF
 
-!DIR$ NOVECTOR
           DO ig = 1, ngw
             ig1 = mill( 1, ig )
             ig2 = mill( 2, ig )
             ig3 = mill( 3, ig )
-!DIR$ NOVECTOR
             DO i = 1, nat
               eigr( ig, i ) = ei1( ig1, i ) * ei2( ig2, i ) * ei3( ig3, i )
             END DO
@@ -154,7 +149,6 @@
       USE kinds,            ONLY: DP
       USE ions_base,        ONLY: nat, na, nsp
       use grid_dimensions,  only: nr1, nr2, nr3
-      use ieee_arithmetic, only: ieee_is_nan
 
       IMPLICIT NONE
 
@@ -174,28 +168,17 @@
       call start_clock( 'strucf' )
 
 !$omp parallel do default(shared), private(ig1,ig2,ig3,isa,is,ia)
-!DIR$ NOVECTOR
       DO ig = 1, ngm
         ig1 = mill( 1, ig ) 
         ig2 = mill( 2, ig ) 
         ig3 = mill( 3, ig )
         isa = 1
-!DIR$ NOVECTOR
         DO is = 1, nsp
           sfac( ig, is ) = CMPLX (0.0d0, 0.0d0)
-!DIR$ NOVECTOR
           DO ia = 1, na(is)
-            if (ieee_is_nan(ei1( ig1, isa )%re)) call errore(' strucf ',' ei1 is NaN ',ig)
-            if (ieee_is_nan(ei1( ig1, isa )%im)) call errore(' strucf ',' ei1 is NaN ',ig)
-            if (ieee_is_nan(ei2( ig2, isa )%re)) call errore(' strucf ',' ei2 is NaN ',ig)
-            if (ieee_is_nan(ei2( ig2, isa )%im)) call errore(' strucf ',' ei2 is NaN ',ig)
-            if (ieee_is_nan(ei3( ig3, isa )%re)) call tracebackqq("ei3 is NaN")
-            if (ieee_is_nan(ei3( ig3, isa )%im)) call tracebackqq("ei3 is NaN")
             sfac( ig, is ) = sfac( ig, is ) + &
               ei1( ig1, isa ) * ei2( ig2, isa ) * ei3( ig3, isa )
             isa = isa + 1
-            if (ieee_is_nan(sfac(ig, is)%re)) call errore(' strucf ',' sfac is NaN ',ig)
-            if (ieee_is_nan(sfac(ig, is)%im)) call errore(' strucf ',' sfac is NaN ',ig)
           END DO
         END DO
       END DO

--- a/CPV/phasefactor.f90
+++ b/CPV/phasefactor.f90
@@ -30,6 +30,7 @@
  
           USE kinds,           ONLY: DP
           USE constants,       ONLY: tpi
+          use ieee_arithmetic, only: ieee_is_nan
 
           IMPLICIT NONE
 
@@ -93,29 +94,33 @@
               ! ...           = exp(-i G_i dot R(ia)) exp(-i (N-1) G_i dot R(ia))
 
               DO i = 1, nr1
-                ei1(  i, isa ) = ei1(  i - 1, isa ) * ctep1
-                ei1( -i, isa ) = ei1( -i + 1, isa ) * ctem1
+                ei1(i, isa) = ei1(0, isa) * ctep1 ** i
+                ei1(-i, isa) = ei1(0, isa) * ctem1 ** i
               END DO
               DO j = 1, nr2
-                ei2(  j, isa ) = ei2(  j - 1, isa ) * ctep2
-                ei2( -j, isa ) = ei2( -j + 1, isa ) * ctem2
+                ei2(j, isa) = ei2(0, isa) * ctep2 ** j
+                ei2(-j, isa) = ei2(0, isa) * ctem2 ** j
               END DO
               DO k = 1, nr3
-                ei3(  k, isa ) = ei3(  k - 1, isa ) * ctep3
-                ei3( -k, isa ) = ei3( -k + 1, isa ) * ctem3
+                ei3(k, isa) = ei3(0, isa) * ctep3 ** k
+                ei3(-k, isa) = ei3(0, isa) * ctem3 ** k
               END DO
-
           END DO
+          write(*, *) 'ei1', ei1
+          write(*, *) 'ei2', ei2
+          write(*, *) 'ei3', ei3
 
           ngw = SIZE( eigr, 1 )
           IF( ngw > SIZE( mill, 2 ) ) THEN
             CALL errore(' phfacs ',' eigr inconsisten size ',ngw)
           END IF
 
+!DIR$ NOVECTOR
           DO ig = 1, ngw
             ig1 = mill( 1, ig )
             ig2 = mill( 2, ig )
             ig3 = mill( 3, ig )
+!DIR$ NOVECTOR
             DO i = 1, nat
               eigr( ig, i ) = ei1( ig1, i ) * ei2( ig2, i ) * ei3( ig3, i )
             END DO
@@ -149,6 +154,7 @@
       USE kinds,            ONLY: DP
       USE ions_base,        ONLY: nat, na, nsp
       use grid_dimensions,  only: nr1, nr2, nr3
+      use ieee_arithmetic, only: ieee_is_nan
 
       IMPLICIT NONE
 
@@ -168,17 +174,28 @@
       call start_clock( 'strucf' )
 
 !$omp parallel do default(shared), private(ig1,ig2,ig3,isa,is,ia)
+!DIR$ NOVECTOR
       DO ig = 1, ngm
         ig1 = mill( 1, ig ) 
         ig2 = mill( 2, ig ) 
         ig3 = mill( 3, ig )
         isa = 1
+!DIR$ NOVECTOR
         DO is = 1, nsp
           sfac( ig, is ) = CMPLX (0.0d0, 0.0d0)
+!DIR$ NOVECTOR
           DO ia = 1, na(is)
+            if (ieee_is_nan(ei1( ig1, isa )%re)) call errore(' strucf ',' ei1 is NaN ',ig)
+            if (ieee_is_nan(ei1( ig1, isa )%im)) call errore(' strucf ',' ei1 is NaN ',ig)
+            if (ieee_is_nan(ei2( ig2, isa )%re)) call errore(' strucf ',' ei2 is NaN ',ig)
+            if (ieee_is_nan(ei2( ig2, isa )%im)) call errore(' strucf ',' ei2 is NaN ',ig)
+            if (ieee_is_nan(ei3( ig3, isa )%re)) call tracebackqq("ei3 is NaN")
+            if (ieee_is_nan(ei3( ig3, isa )%im)) call tracebackqq("ei3 is NaN")
             sfac( ig, is ) = sfac( ig, is ) + &
               ei1( ig1, isa ) * ei2( ig2, isa ) * ei3( ig3, isa )
             isa = isa + 1
+            if (ieee_is_nan(sfac(ig, is)%re)) call errore(' strucf ',' sfac is NaN ',ig)
+            if (ieee_is_nan(sfac(ig, is)%im)) call errore(' strucf ',' sfac is NaN ',ig)
           END DO
         END DO
       END DO


### PR DESCRIPTION
The new intel compiler `ifx` was producing `NaN`s for the simplest of calculations. This was traced back to the function `phfacs_x` in `phasefactor.f90`.

Any of the following changes fix the bug
1.  compiling with `O1` or lower
2.  compiling with `-check bounds`
3. adding `write` statements to the code
4. refactoring the calculation of `ei1`-`ei3`

We do not fully understand the precise nature of the bug. Points 2 and 3 indicate that vectorisation is the issue, since the main difference between `O1` and `O2` is autovectorisation, and `write` statements disable vectorisation, but using `-qopt-report` suggested that in the old implementation the loops weren't being vectorised...

We will potentially submit a bug report to intel, but for the moment we will adopt the refactor as an easy way of avoiding the issue.