### PR TITLE
Print the git branch and git commit hash in the header of the kcp outputs

### DIFF
--- a/CPV/environment.f90
+++ b/CPV/environment.f90
@@ -162,8 +162,8 @@
         & ,5X,'using norm-conserving and ultrasoft Vanderbilt pseudopotentials',//&
         & ,5X,'Version: ',A60,/&
         & ,5X,'Authors: Alfredo Pasquarello, Kari Laasonen, Andrea Trave, Roberto Car,',/&
-        & ,5X,'  Paolo Giannozzi, Nicola Marzari, Carlo Cavazzoni, Guido Chiarotti,',/&
-        & ,5X,'  Sandro Scandolo, Paolo Focher, Gerardo Ballabio, and others',/)
+        & ,5X,'         Paolo Giannozzi, Nicola Marzari, Carlo Cavazzoni, Guido Chiarotti,',/&
+        & ,5X,'         Sandro Scandolo, Paolo Focher, Gerardo Ballabio, and others',/)
 
  3334     FORMAT(/,3X,A60,/)
           RETURN

--- a/CPV/environment.f90
+++ b/CPV/environment.f90
@@ -136,6 +136,7 @@
         SUBROUTINE opening_date_and_time( version_str )
 
           USE io_global, ONLY: stdout, meta_ionode
+          USE global_version
 
           CHARACTER(LEN=*), INTENT(IN) :: version_str
           CHARACTER(LEN=9)  :: cdate, ctime
@@ -150,6 +151,8 @@
           IF( meta_ionode ) THEN
             WRITE( stdout,3331) 
             WRITE( stdout,3332) version_str
+            WRITE( stdout,'(/,5X, "Git Branch: ", A)') TRIM(git_branch) 
+            WRITE( stdout,'(  5X, "Git Commit: ", A, /)') TRIM(git_commit) 
             WRITE( stdout,3331) 
             WRITE( stdout,3334) time_str
           END IF

--- a/CPV/environment.f90
+++ b/CPV/environment.f90
@@ -151,7 +151,7 @@
           IF( meta_ionode ) THEN
             WRITE( stdout,3331) 
             WRITE( stdout,3332) version_str
-            WRITE( stdout,'(/,5X, "Git Branch: ", A)') TRIM(git_branch) 
+            WRITE( stdout,'(  5X, "Git Branch: ", A)') TRIM(git_branch) 
             WRITE( stdout,'(  5X, "Git Commit: ", A, /)') TRIM(git_commit) 
             WRITE( stdout,3331) 
             WRITE( stdout,3334) time_str
@@ -160,10 +160,10 @@
  3331     FORMAT('=',78('-'),'=')
  3332     FORMAT( /, 5X,'CP: variable-cell Car-Parrinello molecular dynamics',/&
         & ,5X,'using norm-conserving and ultrasoft Vanderbilt pseudopotentials',//&
-        & ,5X,'Version: ',A60,/&
-        & ,5X,'Authors: Alfredo Pasquarello, Kari Laasonen, Andrea Trave, Roberto Car,',/&
-        & ,5X,'         Paolo Giannozzi, Nicola Marzari, Carlo Cavazzoni, Guido Chiarotti,',/&
-        & ,5X,'         Sandro Scandolo, Paolo Focher, Gerardo Ballabio, and others',/)
+        & ,5X,'Version:    ',A60,/&
+        & ,5X,'Authors:    Alfredo Pasquarello, Kari Laasonen, Andrea Trave, Roberto Car,',/&
+        & ,5X,'            Paolo Giannozzi, Nicola Marzari, Carlo Cavazzoni, Guido Chiarotti,',/&
+        & ,5X,'            Sandro Scandolo, Paolo Focher, Gerardo Ballabio, and others')
 
  3334     FORMAT(/,3X,A60,/)
           RETURN

--- a/Modules/Makefile
+++ b/Modules/Makefile
@@ -88,16 +88,17 @@ compute_dipole.o #added by giovanni, from trunk version July 2012
 
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 GIT_COMMIT := $(shell git rev-parse HEAD)
-$(shell rm -fr version.h)
 
-all : $(MODULES)
+all : version.h $(MODULES)
 
 clean :
 	- /bin/rm -f *.o *.d *.i *~ *.F90 *.mod *.L
+clean_version :
+	@rm -f version.h
 
 version.o : version.h
 
-version.h :
+version.h : clean_version
 	@echo "CHARACTER(LEN=70), PARAMETER :: version_date = '"`date`"'" \
 		> version.h
 	@echo "CHARACTER(LEN=70), PARAMETER :: git_branch = '"$(GIT_BRANCH)"'" >> version.h

--- a/Modules/Makefile
+++ b/Modules/Makefile
@@ -99,7 +99,7 @@ version.o : version.h
 version.h : clean_version
 	@echo "CHARACTER(LEN=70), PARAMETER :: version_date = '"`date`"'" \
 		> version.h
-	@if [ $(IS_GIT_REPO) = "true" ]; then \
+	@if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then \
 		echo "CHARACTER(LEN=70), PARAMETER :: git_branch = '"`git rev-parse --abbrev-ref HEAD`"'" >> version.h;\
 		echo "CHARACTER(LEN=70), PARAMETER :: git_commit = '"`git rev-parse HEAD`"'" >> version.h;\
 	else \

--- a/Modules/Makefile
+++ b/Modules/Makefile
@@ -85,6 +85,11 @@ read_cards.o \
 read_oddalpha_file.o \
 compute_dipole.o #added by giovanni, from trunk version July 2012 
 
+
+GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+GIT_COMMIT := $(shell git rev-parse HEAD)
+$(shell rm -fr version.h)
+
 all : $(MODULES)
 
 clean :
@@ -93,7 +98,9 @@ clean :
 version.o : version.h
 
 version.h :
-	echo "CHARACTER(LEN=70), PARAMETER :: version_date = '"`date`"'" \
+	@echo "CHARACTER(LEN=70), PARAMETER :: version_date = '"`date`"'" \
 		> version.h
+	@echo "CHARACTER(LEN=70), PARAMETER :: git_branch = '"$(GIT_BRANCH)"'" >> version.h
+	@echo "CHARACTER(LEN=70), PARAMETER :: git_commit = '"$(GIT_COMMIT)"'" >> version.h
 
 include make.depend

--- a/Modules/Makefile
+++ b/Modules/Makefile
@@ -85,9 +85,7 @@ read_cards.o \
 read_oddalpha_file.o \
 compute_dipole.o #added by giovanni, from trunk version July 2012 
 
-
-GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
-GIT_COMMIT := $(shell git rev-parse HEAD)
+IS_GIT_REPO := $(shell git rev-parse --is-inside-work-tree 2>/dev/null)
 
 all : version.h $(MODULES)
 
@@ -101,7 +99,9 @@ version.o : version.h
 version.h : clean_version
 	@echo "CHARACTER(LEN=70), PARAMETER :: version_date = '"`date`"'" \
 		> version.h
-	@echo "CHARACTER(LEN=70), PARAMETER :: git_branch = '"$(GIT_BRANCH)"'" >> version.h
-	@echo "CHARACTER(LEN=70), PARAMETER :: git_commit = '"$(GIT_COMMIT)"'" >> version.h
+	@if [ $(IS_GIT_REPO) = "true" ]; then \
+		echo "CHARACTER(LEN=70), PARAMETER :: git_branch = '"`git rev-parse --abbrev-ref HEAD`"'" >> version.h;\
+		echo "CHARACTER(LEN=70), PARAMETER :: git_commit = '"`git rev-parse HEAD`"'" >> version.h;\
+	fi
 
 include make.depend

--- a/Modules/Makefile
+++ b/Modules/Makefile
@@ -102,6 +102,10 @@ version.h : clean_version
 	@if [ $(IS_GIT_REPO) = "true" ]; then \
 		echo "CHARACTER(LEN=70), PARAMETER :: git_branch = '"`git rev-parse --abbrev-ref HEAD`"'" >> version.h;\
 		echo "CHARACTER(LEN=70), PARAMETER :: git_commit = '"`git rev-parse HEAD`"'" >> version.h;\
+	else \
+		echo "CHARACTER(LEN=70), PARAMETER :: git_branch = '"not a git repo"'" >> version.h;\
+		echo "CHARACTER(LEN=70), PARAMETER :: git_commit = '"not a git repo"'" >> version.h;\
 	fi
+
 
 include make.depend


### PR DESCRIPTION
This MR is to have the git branch and the last git commit printed at the beginning of the `kcp.x` outputs