### PR TITLE
Zero the EE correction arrays at allocation 

### DIFF
--- a/CPV/modules.f90
+++ b/CPV/modules.f90
@@ -641,6 +641,8 @@ contains
   allocate(gcorr2d_fft(nnrx))
   allocate(vcorr(nnrx))
   allocate(vcorr_fft(ngm))
+  vcorr = 0.0_dp
+  vcorr_fft = (0.0_dp, 0.0_dp)
   end subroutine
   !
   subroutine deallocate_ee

--- a/CPV/nksic_corrections.f90
+++ b/CPV/nksic_corrections.f90
@@ -84,6 +84,7 @@ contains
       allocate (rhogaux(ngm, 2))
       allocate (vtmp(ngm))
       allocate (vcorr(ngm))
+      vcorr = (0.0_dp, 0.0_dp)
       allocate (vhaux(nnrx))
       allocate(vsic_realspace(nnrx), source=0.0_dp)
       !
@@ -343,6 +344,7 @@ contains
       allocate (rhogaux(ngm, 2))
       allocate (vtmp(ngm))
       allocate (vcorr(ngm))
+      vcorr = (0.0_dp, 0.0_dp)
       allocate (vxc_(nnrx, 2))
       allocate (vhaux(nnrx))
       !
@@ -626,6 +628,7 @@ contains
       allocate (vtmp(ngm))
       allocate (orb_rhog(ngm, 1))
       allocate (vcorr(ngm))
+      vcorr = (0.0_dp, 0.0_dp)
       allocate (vhaux(nnrx))
       !
       rhoele = 0.0d0

--- a/CPV/perturbing_pot.f90
+++ b/CPV/perturbing_pot.f90
@@ -62,6 +62,7 @@
       ALLOCATE ( vhaux(nnrx) )
       ALLOCATE ( vtmp(ngm) )
       ALLOCATE ( vcorr(ngm) )
+      vcorr = (0.0_DP, 0.0_DP)
       !
       IF (okvan) call errore('perturbing_pot','USPP not implemented yet',1)
       !


### PR DESCRIPTION
The EE correction arrays — the module-level `vcorr`/`vcorr_fft` (`allocate_ee`) and the local `vcorr` arrays in `nksic_corrections.f90`  and `perturbing_pot.f90` — are **allocated but not initialized**.

With `do_ee=.true.` and `which_compensation='none'`,   `calc_compensation_potential` returns without writing them, yet callers read them unconditionally — usually happens to see zeros but could silently corrupt the potential and energy.

This PR zero-initializes these arrays at allocation.